### PR TITLE
Update version to 0.1.24

### DIFF
--- a/sipper_core/metadata.py
+++ b/sipper_core/metadata.py
@@ -1,6 +1,6 @@
 __author__ = 'Paul Gundarapu'
 __author_email__ = 'leogps@outlook.com'
-__version__ = '0.1.23'
+__version__ = '0.1.24'
 __license__ = 'MIT'
 __description__ = 'Simple, zero-configuration command-line static HTTP server.'
 __long_description__ = """


### PR DESCRIPTION
Fixing the app for python 3.12.
    Bug fix: Handling broken links (corner case) on windows when the directory path passed does not end with /.
    sipper.await_sipping_complete() method to await for (join on) all the server threads to complete.